### PR TITLE
Message transform

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -7,17 +8,18 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         bootstrap="tests/bootstrap.php">
-
-    <testsuite name="Test Suite">
-        <directory>./tests</directory>
-    </testsuite>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">.</directory>
-            <exclude>
-                <directory suffix=".php">vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+         bootstrap="tests/bootstrap.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuite name="Test Suite">
+    <directory>./tests</directory>
+  </testsuite>
 </phpunit>

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -35,7 +35,7 @@ class ExceptionListener
     public function onKernelException(ExceptionEvent $event): void
     {
         $message = ExceptionTransformer::transformException($this->logger, $event->getThrowable());
-        $response = new JsonResponse($message->getMessage(), $message->getStatusCode(), $this->getHeaders());
+        $response = new JsonResponse($message->getArray(), $message->getStatusCode(), $this->getHeaders());
         $response->setEncodingOptions(0);
         $event->setResponse($response);
     }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Keboola\ErrorControl\EventListener;
 
+use Keboola\CommonExceptions\UserExceptionInterface;
 use Keboola\ErrorControl\Message\ExceptionTransformer;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class ExceptionListener
 {
@@ -34,7 +36,13 @@ class ExceptionListener
 
     public function onKernelException(ExceptionEvent $event): void
     {
-        $message = ExceptionTransformer::transformException($this->logger, $event->getThrowable());
+        $exception = $event->getThrowable();
+        $message = ExceptionTransformer::transformException($exception);
+        if (($exception instanceof HttpExceptionInterface) || ($exception instanceof UserExceptionInterface)) {
+            $this->logger->error($exception->getMessage(), $message->getFullArray());
+        } else {
+            $this->logger->critical($exception->getMessage(), $message->getFullArray());
+        }
         $response = new JsonResponse($message->getSafeArray(), $message->getStatusCode(), $this->getHeaders());
         $response->setEncodingOptions(0);
         $event->setResponse($response);

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -35,7 +35,7 @@ class ExceptionListener
     public function onKernelException(ExceptionEvent $event): void
     {
         $message = ExceptionTransformer::transformException($this->logger, $event->getThrowable());
-        $response = new JsonResponse($message->getArray(), $message->getStatusCode(), $this->getHeaders());
+        $response = new JsonResponse($message->getSafeArray(), $message->getStatusCode(), $this->getHeaders());
         $response->setEncodingOptions(0);
         $event->setResponse($response);
     }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -4,15 +4,10 @@ declare(strict_types=1);
 
 namespace Keboola\ErrorControl\EventListener;
 
-use Keboola\CommonExceptions\ExceptionWithContextInterface;
-use Keboola\CommonExceptions\UserExceptionInterface;
+use Keboola\ErrorControl\Message\ExceptionTransformer;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
-use Throwable;
 
 class ExceptionListener
 {
@@ -37,66 +32,11 @@ class ExceptionListener
         ];
     }
 
-    private function getExceptionMessage(Throwable $exception): string
-    {
-        if (is_a($exception, UserExceptionInterface::class) || is_a($exception, HttpException::class)) {
-            return  $exception->getMessage();
-        }
-        return 'Internal Server Error occurred.';
-    }
-
-    private function getExceptionId(): string
-    {
-        return 'exception-' . md5(microtime());
-    }
-
     public function onKernelException(ExceptionEvent $event): void
     {
-        $exception = $event->getThrowable();
-        $exceptionId = $this->getExceptionId();
-        if ($exception instanceof HttpExceptionInterface) {
-            $statusCode = $exception->getStatusCode();
-            $code = $statusCode;
-            $this->logger->error($exception->getMessage(), [
-                'exceptionId' => $exceptionId,
-                'exception' => $exception,
-                'context' => $this->getExceptionContext($exception),
-            ]);
-        } elseif ($exception instanceof UserExceptionInterface) {
-            $statusCode = $exception->getCode() ? $exception->getCode() : Response::HTTP_BAD_REQUEST;
-            $code = $exception->getCode();
-            $this->logger->error($exception->getMessage(), [
-                'exceptionId' => $exceptionId,
-                'exception' => $exception,
-                'context' => $this->getExceptionContext($exception),
-            ]);
-        } else {
-            $statusCode = Response::HTTP_INTERNAL_SERVER_ERROR;
-            $code = $exception->getCode();
-            $this->logger->critical($exception->getMessage(), [
-                'exceptionId' => $exceptionId,
-                'exception' => $exception,
-                'context' => $this->getExceptionContext($exception),
-            ]);
-        }
-
-        $message = [
-            'error' => $this->getExceptionMessage($exception),
-            'code' => $code,
-            'exceptionId' => $exceptionId,
-            'status' => 'error',
-            'context' => $this->getExceptionContext($exception),
-        ];
-        $response = new JsonResponse($message, $statusCode, $this->getHeaders());
+        $message = ExceptionTransformer::transformException($this->logger, $event->getThrowable());
+        $response = new JsonResponse($message->getMessage(), $message->getStatusCode(), $this->getHeaders());
         $response->setEncodingOptions(0);
         $event->setResponse($response);
-    }
-
-    private function getExceptionContext(\Throwable $exception): ?array
-    {
-        if ($exception instanceof ExceptionWithContextInterface) {
-            return $exception->getContext();
-        }
-        return null;
     }
 }

--- a/src/Message/ExceptionMessage.php
+++ b/src/Message/ExceptionMessage.php
@@ -31,11 +31,6 @@ class ExceptionMessage
         $this->context = $context;
     }
 
-    public function getStatusCode(): int
-    {
-        return $this->statusCode;
-    }
-
     public function getSafeArray(): array
     {
         $data = $this->getFullArray();
@@ -53,5 +48,35 @@ class ExceptionMessage
             'status' => 'error',
             'context' => $this->context,
         ];
+    }
+
+    public function getError(): string
+    {
+        return $this->error;
+    }
+
+    public function getCode(): int
+    {
+        return $this->code;
+    }
+
+    public function getException(): Throwable
+    {
+        return $this->exception;
+    }
+
+    public function getExceptionId(): string
+    {
+        return $this->exceptionId;
+    }
+
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
     }
 }

--- a/src/Message/ExceptionMessage.php
+++ b/src/Message/ExceptionMessage.php
@@ -36,11 +36,19 @@ class ExceptionMessage
         return $this->statusCode;
     }
 
-    public function getArray(): array
+    public function getSafeArray(): array
+    {
+        $data = $this->getFullArray();
+        unset($data['exception']);
+        return $data;
+    }
+
+    public function getFullArray(): array
     {
         return [
             'error' => $this->error,
             'code' => $this->code,
+            'exception' => $this->exception,
             'exceptionId' => $this->exceptionId,
             'status' => 'error',
             'context' => $this->context,

--- a/src/Message/ExceptionMessage.php
+++ b/src/Message/ExceptionMessage.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ErrorControl\Message;
+
+class ExceptionMessage
+{
+    /** @var int */
+    private $statusCode;
+    /** @var string */
+    private $error;
+    /** @var int */
+    private $code;
+    /** @var string */
+    private $exceptionId;
+    /** @var array */
+    private $context;
+
+    public function __construct(string $error, int $code, string $exceptionId, int $statusCode, array $context)
+    {
+        $this->statusCode = $statusCode;
+        $this->error = $error;
+        $this->code = $code;
+        $this->exceptionId = $exceptionId;
+        $this->context = $context;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getMessage(): array
+    {
+        return [
+            'error' => $this->error,
+            'code' => $this->code,
+            'exceptionId' => $this->exceptionId,
+            'status' => 'error',
+            'context' => $this->context,
+        ];
+    }
+}

--- a/src/Message/ExceptionMessage.php
+++ b/src/Message/ExceptionMessage.php
@@ -4,25 +4,30 @@ declare(strict_types=1);
 
 namespace Keboola\ErrorControl\Message;
 
+use Throwable;
+
 class ExceptionMessage
 {
-    /** @var int */
-    private $statusCode;
     /** @var string */
     private $error;
     /** @var int */
     private $code;
+    /** @var Throwable */
+    private $exception;
     /** @var string */
     private $exceptionId;
+    /** @var int */
+    private $statusCode;
     /** @var array */
     private $context;
 
-    public function __construct(string $error, int $code, string $exceptionId, int $statusCode, array $context)
+    public function __construct(string $error, int $code, Throwable $exception, string $exceptionId, int $statusCode, array $context)
     {
-        $this->statusCode = $statusCode;
         $this->error = $error;
         $this->code = $code;
+        $this->exception = $exception;
         $this->exceptionId = $exceptionId;
+        $this->statusCode = $statusCode;
         $this->context = $context;
     }
 
@@ -31,7 +36,7 @@ class ExceptionMessage
         return $this->statusCode;
     }
 
-    public function getMessage(): array
+    public function getArray(): array
     {
         return [
             'error' => $this->error,

--- a/src/Message/ExceptionMessage.php
+++ b/src/Message/ExceptionMessage.php
@@ -21,8 +21,14 @@ class ExceptionMessage
     /** @var array */
     private $context;
 
-    public function __construct(string $error, int $code, Throwable $exception, string $exceptionId, int $statusCode, array $context)
-    {
+    public function __construct(
+        string $error,
+        int $code,
+        Throwable $exception,
+        string $exceptionId,
+        int $statusCode,
+        array $context
+    ) {
         $this->error = $error;
         $this->code = $code;
         $this->exception = $exception;

--- a/src/Message/ExceptionTransformer.php
+++ b/src/Message/ExceptionTransformer.php
@@ -6,7 +6,6 @@ namespace Keboola\ErrorControl\Message;
 
 use Keboola\CommonExceptions\ExceptionWithContextInterface;
 use Keboola\CommonExceptions\UserExceptionInterface;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -35,33 +34,18 @@ class ExceptionTransformer
         return [];
     }
 
-    public static function transformException(LoggerInterface $logger, Throwable $exception): ExceptionMessage
+    public static function transformException(Throwable $exception): ExceptionMessage
     {
         $exceptionId = self::getExceptionId();
         if ($exception instanceof HttpExceptionInterface) {
             $statusCode = $exception->getStatusCode();
             $code = $statusCode;
-            $logger->error($exception->getMessage(), [
-                'exceptionId' => $exceptionId,
-                'exception' => $exception,
-                'context' => self::getExceptionContext($exception),
-            ]);
         } elseif ($exception instanceof UserExceptionInterface) {
             $statusCode = $exception->getCode() ? $exception->getCode() : Response::HTTP_BAD_REQUEST;
             $code = $exception->getCode();
-            $logger->error($exception->getMessage(), [
-                'exceptionId' => $exceptionId,
-                'exception' => $exception,
-                'context' => self::getExceptionContext($exception),
-            ]);
         } else {
             $statusCode = Response::HTTP_INTERNAL_SERVER_ERROR;
             $code = $exception->getCode();
-            $logger->critical($exception->getMessage(), [
-                'exceptionId' => $exceptionId,
-                'exception' => $exception,
-                'context' => self::getExceptionContext($exception),
-            ]);
         }
 
         return new ExceptionMessage(

--- a/src/Message/ExceptionTransformer.php
+++ b/src/Message/ExceptionTransformer.php
@@ -67,6 +67,7 @@ class ExceptionTransformer
         return new ExceptionMessage(
             self::getExceptionMessage($exception),
             $code,
+            $exception,
             $exceptionId,
             $statusCode,
             self::getExceptionContext($exception)

--- a/src/Message/ExceptionTransformer.php
+++ b/src/Message/ExceptionTransformer.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ErrorControl\Message;
+
+use Keboola\CommonExceptions\ExceptionWithContextInterface;
+use Keboola\CommonExceptions\UserExceptionInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Throwable;
+
+class ExceptionTransformer
+{
+    private static function getExceptionMessage(Throwable $exception): string
+    {
+        if (is_a($exception, UserExceptionInterface::class) || is_a($exception, HttpException::class)) {
+            return  $exception->getMessage();
+        }
+        return 'Internal Server Error occurred.';
+    }
+
+    private static function getExceptionId(): string
+    {
+        return 'exception-' . md5(microtime());
+    }
+
+    private static function getExceptionContext(\Throwable $exception): array
+    {
+        if ($exception instanceof ExceptionWithContextInterface) {
+            return $exception->getContext();
+        }
+        return [];
+    }
+
+    public static function transformException(LoggerInterface $logger, Throwable $exception): ExceptionMessage
+    {
+        $exceptionId = self::getExceptionId();
+        if ($exception instanceof HttpExceptionInterface) {
+            $statusCode = $exception->getStatusCode();
+            $code = $statusCode;
+            $logger->error($exception->getMessage(), [
+                'exceptionId' => $exceptionId,
+                'exception' => $exception,
+                'context' => self::getExceptionContext($exception),
+            ]);
+        } elseif ($exception instanceof UserExceptionInterface) {
+            $statusCode = $exception->getCode() ? $exception->getCode() : Response::HTTP_BAD_REQUEST;
+            $code = $exception->getCode();
+            $logger->error($exception->getMessage(), [
+                'exceptionId' => $exceptionId,
+                'exception' => $exception,
+                'context' => self::getExceptionContext($exception),
+            ]);
+        } else {
+            $statusCode = Response::HTTP_INTERNAL_SERVER_ERROR;
+            $code = $exception->getCode();
+            $logger->critical($exception->getMessage(), [
+                'exceptionId' => $exceptionId,
+                'exception' => $exception,
+                'context' => self::getExceptionContext($exception),
+            ]);
+        }
+
+        return new ExceptionMessage(
+            self::getExceptionMessage($exception),
+            $code,
+            $exceptionId,
+            $statusCode,
+            self::getExceptionContext($exception)
+        );
+    }
+}

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -58,11 +58,11 @@ class ExceptionListenerTest extends TestCase
         self::assertEquals('12', $responseBody['code']);
         self::assertEquals('Internal Server Error occurred.', $responseBody['error']);
         self::assertEquals('error', $responseBody['status']);
-        self::assertEquals(null, $responseBody['context']);
+        self::assertEquals([], $responseBody['context']);
         $record = $handler->getRecords()[0];
         self::assertEquals(Logger::CRITICAL, $record['level']);
         self::assertEquals($exception, $record['context']['exception']);
-        self::assertEquals(null, $record['context']['context']);
+        self::assertEquals([], $record['context']['context']);
         self::assertStringStartsWith('exception-', $record['context']['exceptionId']);
     }
 
@@ -92,11 +92,11 @@ class ExceptionListenerTest extends TestCase
         self::assertEquals('421', $responseBody['code']);
         self::assertEquals('test user exception', $responseBody['error']);
         self::assertEquals('error', $responseBody['status']);
-        self::assertEquals(null, $responseBody['context']);
+        self::assertEquals([], $responseBody['context']);
         $record = $handler->getRecords()[0];
         self::assertEquals(Logger::ERROR, $record['level']);
         self::assertEquals($exception, $record['context']['exception']);
-        self::assertEquals(null, $record['context']['context']);
+        self::assertEquals([], $record['context']['context']);
         self::assertStringStartsWith('exception-', $record['context']['exceptionId']);
     }
 
@@ -232,11 +232,11 @@ class ExceptionListenerTest extends TestCase
         self::assertEquals('0', $responseBody['code']);
         self::assertEquals('test user exception', $responseBody['error']);
         self::assertEquals('error', $responseBody['status']);
-        self::assertEquals(null, $responseBody['context']);
+        self::assertEquals([], $responseBody['context']);
         $record = $handler->getRecords()[0];
         self::assertEquals(Logger::ERROR, $record['level']);
         self::assertEquals($exception, $record['context']['exception']);
-        self::assertEquals(null, $record['context']['context']);
+        self::assertEquals([], $record['context']['context']);
         self::assertStringStartsWith('exception-', $record['context']['exceptionId']);
     }
 
@@ -265,11 +265,11 @@ class ExceptionListenerTest extends TestCase
         self::assertEquals('403', $responseBody['code']);
         self::assertEquals('test HTTP exception', $responseBody['error']);
         self::assertEquals('error', $responseBody['status']);
-        self::assertEquals(null, $responseBody['context']);
+        self::assertEquals([], $responseBody['context']);
         $record = $handler->getRecords()[0];
         self::assertEquals(Logger::ERROR, $record['level']);
         self::assertEquals($exception, $record['context']['exception']);
-        self::assertEquals(null, $record['context']['context']);
+        self::assertEquals([], $record['context']['context']);
         self::assertStringStartsWith('exception-', $record['context']['exceptionId']);
     }
 
@@ -294,7 +294,7 @@ class ExceptionListenerTest extends TestCase
         self::assertNotNull($response);
         self::assertEquals(1, preg_match(
             '#{"error":"test exception with special \\\" \' characters < > \^ \$ & end","code":0,' .
-            '"exceptionId":"exception-[a-z0-9]+","status":"error","context":null}#',
+            '"exceptionId":"exception-[a-z0-9]+","status":"error","context":\[\]}#',
             (string) $response->getContent()
         ));
     }

--- a/tests/Message/ExceptionMessageTest.php
+++ b/tests/Message/ExceptionMessageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Keboola\ErrorControl\Tests\Message;
 
 use Keboola\ErrorControl\Message\ExceptionMessage;

--- a/tests/Message/ExceptionMessageTest.php
+++ b/tests/Message/ExceptionMessageTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Keboola\ErrorControl\Tests\Message;
+
+use Keboola\ErrorControl\Message\ExceptionMessage;
+use PHPUnit\Framework\TestCase;
+
+class ExceptionMessageTest extends TestCase
+{
+    public function testAccessors(): void
+    {
+        $ex = new \Exception('test');
+        $message = new ExceptionMessage('foo', 123, $ex, 'abc123', 300, ['foo' => 'bar']);
+        self::assertEquals('foo', $message->getError());
+        self::assertEquals(123, $message->getCode());
+        self::assertEquals('test', $message->getException()->getMessage());
+        self::assertEquals('abc123', $message->getExceptionId());
+        self::assertEquals(300, $message->getStatusCode());
+        self::assertEquals(['foo' => 'bar'], $message->getContext());
+        self::assertEquals(
+            [
+                'error' => 'foo',
+                'code' => 123,
+                'exception' => $ex,
+                'exceptionId' => 'abc123',
+                'status' => 'error',
+                'context' => ['foo' => 'bar'],
+            ],
+            $message->getFullArray()
+        );
+        self::assertEquals(
+            [
+                'error' => 'foo',
+                'code' => 123,
+                'exceptionId' => 'abc123',
+                'status' => 'error',
+                'context' => ['foo' => 'bar'],
+            ],
+            $message->getSafeArray()
+        );
+    }
+}

--- a/tests/Message/ExceptionTransformerTest.php
+++ b/tests/Message/ExceptionTransformerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Keboola\ErrorControl\Tests\Message;
 
 use Keboola\CommonExceptions\ExceptionWithContextInterface;

--- a/tests/Message/ExceptionTransformerTest.php
+++ b/tests/Message/ExceptionTransformerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Keboola\ErrorControl\Tests\Message;
+
+use Keboola\CommonExceptions\ExceptionWithContextInterface;
+use Keboola\CommonExceptions\UserExceptionInterface;
+use Keboola\ErrorControl\Message\ExceptionTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class ExceptionTransformerTest extends TestCase
+{
+    public function testTransform(): void
+    {
+        $ex = new \Exception('test');
+        $message = ExceptionTransformer::transformException($ex)->getFullArray();
+        self::assertStringContainsString('exception-', $message['exceptionId']);
+        unset($message['exceptionId']);
+        self::assertEquals(
+            [
+                'error' => 'Internal Server Error occurred.',
+                'code' => 0,
+                'exception' => $ex,
+                'status' => 'error',
+                'context' => [],
+            ],
+            $message
+        );
+    }
+
+    public function testTransformUserException(): void
+    {
+        $ex = new class('test') extends \Exception implements UserExceptionInterface {
+        };
+        $message = ExceptionTransformer::transformException($ex)->getFullArray();
+        self::assertStringContainsString('exception-', $message['exceptionId']);
+        unset($message['exceptionId']);
+        self::assertInstanceOf(UserExceptionInterface::class, $message['exception']);
+        unset($message['exception']);
+        self::assertEquals(
+            [
+                'error' => 'test',
+                'code' => 0,
+                'status' => 'error',
+                'context' => [],
+            ],
+            $message
+        );
+    }
+
+    public function testTransformHttpException(): void
+    {
+        $ex = new class('test') extends \Exception implements HttpExceptionInterface {
+            public function getStatusCode(): int
+            {
+                return 123;
+            }
+
+            public function getHeaders(): array
+            {
+                return [];
+            }
+        };
+        $message = ExceptionTransformer::transformException($ex)->getFullArray();
+        self::assertStringContainsString('exception-', $message['exceptionId']);
+        unset($message['exceptionId']);
+        self::assertInstanceOf(HttpExceptionInterface::class, $message['exception']);
+        unset($message['exception']);
+        self::assertEquals(
+            [
+                'error' => 'Internal Server Error occurred.',
+                'code' => 123,
+                'status' => 'error',
+                'context' => [],
+            ],
+            $message
+        );
+    }
+
+    public function testTransformContextException(): void
+    {
+        $ex = new class('test') extends \Exception implements ExceptionWithContextInterface {
+            public function getContext(): array
+            {
+                return ['bar' => 'Kochba'];
+            }
+        };
+        $message = ExceptionTransformer::transformException($ex)->getFullArray();
+        self::assertStringContainsString('exception-', $message['exceptionId']);
+        unset($message['exceptionId']);
+        self::assertInstanceOf(ExceptionWithContextInterface::class, $message['exception']);
+        unset($message['exception']);
+        self::assertEquals(
+            [
+                'error' => 'Internal Server Error occurred.',
+                'code' => 0,
+                'status' => 'error',
+                'context' => ['bar' => 'Kochba'],
+            ],
+            $message
+        );
+    }
+}


### PR DESCRIPTION
refactor: move the exception transforming logic to a separate class
chore: update deprecated phpunit configuration

V testech se změnilo to, že prázdný context je prázdné pole a byl to null. To by snad nemělo nic rozbít a dost to tam zavazelo (`?array`)