### PR TITLE
PS-2323 Create ErrorResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,19 @@ $logProcessor->setLogInfo(new LogInfo(...));
 ```
 
 ## Development
+### AWS resources
 Use the provided `test-cf-stack.json` to create a CloudFormation stack. Use the outputs to set environment variables
 `AWS_DEFAULT_REGION`, `S3_LOGS_BUCKET`. Create an access key for the generated user. Set it to the environment 
 variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`.
+
+### Azure resources
 Use the provided `test-arm-template.json` to create ARM stack:
 
     az group create --name testing-api-error-control --location "East US"
 
     az deployment group create --resource-group testing-api-error-control --template-file test-arm-template.json --parameters storage_account_name=testingapierrorcontrol container_name=test-container
 
-Go to the [Azure Portal](https://portal.azure.com/) - Storage Account - Access Keys and copy connection string. 
+Go to the [Azure Portal](https://portal.azure.com/) > Storage Account > testingapierrorcontrol > Access Keys and copy connection string. 
 Go to Storage Account - Lifecycle Management - and set a cleanup rule to remove files older than 1 day from the container.
 Set  `ABS_CONNECTION_STRING` and `ABS_CONTAINER`. Run tests with `composer ci`. 
 
@@ -93,4 +96,3 @@ services:
 
 In case you were using `S3Uploader` directly somewhere, you have to replace the occurrences with `UploaderFactory` 
 and call `getUploader()` method to actually get an uploader.
-  

--- a/src/ErrorResponse.php
+++ b/src/ErrorResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ErrorControl;
+
+use Keboola\ErrorControl\Message\ExceptionMessage;
+use Keboola\ErrorControl\Message\ExceptionTransformer;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Throwable;
+
+class ErrorResponse extends JsonResponse
+{
+    private const HEADERS = [
+        'Access-Control-Allow-Origin' => '*',
+        'Access-Control-Allow-Methods' => '*',
+        'Access-Control-Allow-Headers' => '*',
+        'Cache-Control' => 'private, no-cache, no-store, must-revalidate',
+        'Content-Type' => 'application/json',
+    ];
+
+    /**
+     * @var int
+     */
+    protected $encodingOptions = 0;
+
+    public function __construct(ExceptionMessage $message)
+    {
+        parent::__construct($message->getSafeArray(), $message->getStatusCode(), self::HEADERS);
+    }
+
+    public static function fromException(Throwable $error): self
+    {
+        $message = ExceptionTransformer::transformException($error);
+        return new self($message);
+    }
+}

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Keboola\ErrorControl\EventListener;
 
 use Keboola\CommonExceptions\UserExceptionInterface;
+use Keboola\ErrorControl\ErrorResponse;
 use Keboola\ErrorControl\Message\ExceptionTransformer;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
@@ -23,28 +23,17 @@ class ExceptionListener
         $this->logger = $logger;
     }
 
-    private function getHeaders(): array
-    {
-        return [
-            'Access-Control-Allow-Origin' => '*',
-            'Access-Control-Allow-Methods' => '*',
-            'Access-Control-Allow-Headers' => '*',
-            'Cache-Control' => 'private, no-cache, no-store, must-revalidate',
-            'Content-Type' => 'application/json',
-        ];
-    }
-
     public function onKernelException(ExceptionEvent $event): void
     {
         $exception = $event->getThrowable();
         $message = ExceptionTransformer::transformException($exception);
-        if (($exception instanceof HttpExceptionInterface) || ($exception instanceof UserExceptionInterface)) {
+
+        if ($exception instanceof HttpExceptionInterface || $exception instanceof UserExceptionInterface) {
             $this->logger->error($exception->getMessage(), $message->getFullArray());
         } else {
             $this->logger->critical($exception->getMessage(), $message->getFullArray());
         }
-        $response = new JsonResponse($message->getSafeArray(), $message->getStatusCode(), $this->getHeaders());
-        $response->setEncodingOptions(0);
-        $event->setResponse($response);
+
+        $event->setResponse(new ErrorResponse($message));
     }
 }

--- a/src/ExceptionIdGenerator.php
+++ b/src/ExceptionIdGenerator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ErrorControl;
+
+class ExceptionIdGenerator
+{
+    public static function generateId(): string
+    {
+        return 'exception-' . md5(microtime());
+    }
+}

--- a/tests/ErrorResponseTest.php
+++ b/tests/ErrorResponseTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ErrorControl\Tests;
+
+use Keboola\ErrorControl\ErrorResponse;
+use Keboola\ErrorControl\Message\ExceptionMessage;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ErrorResponseTest extends TestCase
+{
+    public function testNewResponse(): void
+    {
+        $exceptionMessage = new ExceptionMessage(
+            'error message',
+            123,
+            new \Exception(),
+            'exceptionId',
+            456,
+            []
+        );
+
+        $response = new ErrorResponse($exceptionMessage);
+
+        self::assertSame('application/json', $response->headers->get('Content-Type'));
+        self::assertSame('must-revalidate, no-cache, no-store, private', $response->headers->get('Cache-Control'));
+        self::assertSame('*', $response->headers->get('Access-Control-Allow-Origin'));
+        self::assertSame('*', $response->headers->get('Access-Control-Allow-Methods'));
+        self::assertSame('*', $response->headers->get('Access-Control-Allow-Headers'));
+        self::assertSame(456, $response->getStatusCode());
+
+        $responseData = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('exceptionId', $responseData);
+        unset($responseData['exceptionId']);
+
+        self::assertSame([
+            'error' => 'error message',
+            'code' => 123,
+            'status' => 'error',
+            'context' => [],
+        ], $responseData);
+    }
+
+    public function testCreateFromException(): void
+    {
+        $exception = new RuntimeException('Error occurred', 123);
+
+        $response = ErrorResponse::fromException($exception);
+
+        self::assertSame('application/json', $response->headers->get('Content-Type'));
+        self::assertSame('must-revalidate, no-cache, no-store, private', $response->headers->get('Cache-Control'));
+        self::assertSame('*', $response->headers->get('Access-Control-Allow-Origin'));
+        self::assertSame('*', $response->headers->get('Access-Control-Allow-Methods'));
+        self::assertSame('*', $response->headers->get('Access-Control-Allow-Headers'));
+        self::assertSame(500, $response->getStatusCode());
+
+        $responseData = json_decode((string) $response->getContent(), true);
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('exceptionId', $responseData);
+        unset($responseData['exceptionId']);
+
+        self::assertSame([
+            'error' => 'Internal Server Error occurred.',
+            'code' => 123,
+            'status' => 'error',
+            'context' => [],
+        ], $responseData);
+    }
+}

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -64,6 +64,7 @@ class ExceptionListenerTest extends TestCase
         self::assertEquals($exception, $record['context']['exception']);
         self::assertEquals([], $record['context']['context']);
         self::assertStringStartsWith('exception-', $record['context']['exceptionId']);
+        self::assertSame($responseBody['exceptionId'], $record['context']['exceptionId']);
     }
 
     public function testHandleUserExceptionInterface(): void
@@ -98,6 +99,7 @@ class ExceptionListenerTest extends TestCase
         self::assertEquals($exception, $record['context']['exception']);
         self::assertEquals([], $record['context']['context']);
         self::assertStringStartsWith('exception-', $record['context']['exceptionId']);
+        self::assertSame($responseBody['exceptionId'], $record['context']['exceptionId']);
     }
 
     public function exceptionsWithContextProvider(): \Generator
@@ -202,6 +204,7 @@ class ExceptionListenerTest extends TestCase
             ],
         ], $record['context']['context']);
         self::assertStringStartsWith('exception-', $record['context']['exceptionId']);
+        self::assertSame($responseBody['exceptionId'], $record['context']['exceptionId']);
     }
 
     public function testHandleUserExceptionZero(): void
@@ -238,6 +241,7 @@ class ExceptionListenerTest extends TestCase
         self::assertEquals($exception, $record['context']['exception']);
         self::assertEquals([], $record['context']['context']);
         self::assertStringStartsWith('exception-', $record['context']['exceptionId']);
+        self::assertSame($responseBody['exceptionId'], $record['context']['exceptionId']);
     }
 
     public function testHandleHttpException(): void
@@ -271,6 +275,7 @@ class ExceptionListenerTest extends TestCase
         self::assertEquals($exception, $record['context']['exception']);
         self::assertEquals([], $record['context']['context']);
         self::assertStringStartsWith('exception-', $record['context']['exceptionId']);
+        self::assertSame($responseBody['exceptionId'], $record['context']['exceptionId']);
     }
 
     public function testExceptionEncoding(): void


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2325

* vytvoreni `ErrorResponse`, takze lze jednoduse vracet spravne formatovane errory i z appek
* uprava `LogProcessor` tak, aby umel zpracovat exception, aniz by pochazela z `ExceptionListener` (viz. ukazka)

```
try {
  ...
} catch (\Throwable $e) {
  $this->logger->error('Something bad happened', [
    'exception' => $e,
  ]);
}